### PR TITLE
fix(sponsor): Change URL for Alkivi. Website instead of Github

### DIFF
--- a/templates/_sponsors.jinja2
+++ b/templates/_sponsors.jinja2
@@ -340,7 +340,7 @@ GitGuardian solutions monitor public and private repositories in real-time, dete
       },
 
       'Bronze': {
-	  'Alkivi': 'https://github.com/alkivi-sas/',
+	  'Alkivi': 'https://alkivi.fr/',
 	  'MyBeezBox': 'https://www.mybeezbox.com/',
 	  'Emencia': 'https://www.emencia.com/',
 	  'Yaal Coop': 'https://yaal.coop/',


### PR DESCRIPTION
Hello, 

Je voulais juste mettre le site web d'alkivi au lieu du Github sur la page principale des Sponsor :) 

Merci d'avance,